### PR TITLE
:ambulance: open-api-3.0.1.json을 찾지 못하는 문제 해결

### DIFF
--- a/module-web/build.gradle
+++ b/module-web/build.gradle
@@ -23,6 +23,9 @@ bootJar {
     dependsOn(
             'openapi3',
     )
+    from("$apiDir/open-api-3.0.1.json") {
+        into 'BOOT-INF/classes/static/docs/api'
+    }
 }
 
 jar {
@@ -33,7 +36,6 @@ jar {
         epages settings
 ------------------------------- */
 openapi3 {
-    delete "$apiDir/open-api-3.0.1.json"
     servers = [
             {
                 url = 'https://www.ark-inflearn.shop'


### PR DESCRIPTION
빌드시 해당 파일을 반드시 jar에 포함시켜 빌드하도록 빌드 스크립트 작성