### PR TITLE
누락되었던 Redis Configuration 복구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ subprojects {
                 'commons-io:commons-io:2.8.0',
                 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.7.1',
                 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3',
+                'org.springframework.boot:spring-boot-starter-data-redis',
+                'org.springframework.session:spring-session-data-redis',
         )
 
         testImplementation(

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@ else
         sleep 3
 fi
 
-chmod -x $BUILD_PATH/$JAR_NAME
+chmod +x $BUILD_PATH/$JAR_NAME
 
 nohup java -jar -Dserver.port=8081 -Djasypt.encryptor.password="$JASYPT_PASSWORD" -Dspring.profiles.active=prod $BUILD_PATH/$JAR_NAME >> /dev/null &
 echo "[$(date)] 배포 완료 !" >> /home/ubuntu/deploy.log

--- a/module-common/src/main/java/com/ark/sprout/redis/RedisConfiguration.java
+++ b/module-common/src/main/java/com/ark/sprout/redis/RedisConfiguration.java
@@ -23,7 +23,7 @@ public class RedisConfiguration {
 
     @Bean
     public LettuceConnectionFactory lettuceConnectionFactory() {
-        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+        final RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
         redisStandaloneConfiguration.setPassword(RedisPassword.of(password));
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }

--- a/module-common/src/main/java/com/ark/sprout/redis/RedisConfiguration.java
+++ b/module-common/src/main/java/com/ark/sprout/redis/RedisConfiguration.java
@@ -1,0 +1,38 @@
+package com.ark.sprout.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfiguration {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.password}")
+    private String password;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory lettuceConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+        redisStandaloneConfiguration.setPassword(RedisPassword.of(password));
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        final RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(lettuceConnectionFactory());
+        template.setDefaultSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/module-common/src/main/resources/application.yml
+++ b/module-common/src/main/resources/application.yml
@@ -39,8 +39,14 @@ spring:
             tokenUri: https://graph.facebook.com/v3.0/oauth/access_token
             userInfoUri: https://graph.facebook.com/v11.0/me?fields=id,name,email,verified,is_verified
 
+  redis:
+    host: ENC(WwKyD0rAnvn9H7UC1lWAPkB5fbGVOczw)
+    password: ENC(afRb1u+3xSg9mvZhZQiK6g09Qo09dQT5yg4Y26rTMW8=)
+    port: 6379
+
   session:
     timeout: 120m
+    store-type: redis
 
 logging:
   level:


### PR DESCRIPTION
이전에 작업했던 #151 Redis 세션 클러스터링 작업이 날라갔던 부분을 복구하였습니다.

멀티 모듈이라 Redis 라이브러리를 어디에 추가해야할지가 생각보다 많이 헷갈렸습니다.

최상위 `root`에 위치시키고 `common`에 `RedisConfiguration`을 작성하는 식으로 작업을 진행하였습니다.

추가적인 의견있으면 말씀해주세요😂

별도로 주셨던 피드백도 반영하였습니다.
- `RedisConfiguration`이라는 클래스 명을 가지고 있기 때문에 `redisHost`보다는 `host` 필드가 더 적절한 것 같다.
- 무중단 배포에서 `chmod -`는 권한을 뺏는 것이기 때문에 `chmod +`가 맞지 않을까?